### PR TITLE
qemu-guest-agent socket wrapper for provisioning command execution

### DIFF
--- a/backend/import_machine_templates.py
+++ b/backend/import_machine_templates.py
@@ -175,11 +175,14 @@ def convert_iso_to_machine_template(disk_file_path, machine_template_id):
         raise RuntimeError(f"Failed to import ISO file: {e1}")
 
 
-def wait_for_cloud_init_completion(machine, timeout=600):
+def wait_for_cloud_init_completion(machine, timeout=900, socket_wait_timeout=120.0):
     """
     Wait until Cloud-init finishes and the setup script completes.
     Checks for a flag file created by the setup script and verifies systemd timer.
     """
+    _CLOUD_INIT_EXEC_TIMEOUT = max(timeout - 60, 120)
+    _FAST_EXEC_TIMEOUT = 15
+
     checks = {
         'cloud_init': False,
         'bash_logging_timer': False,
@@ -189,15 +192,21 @@ def wait_for_cloud_init_completion(machine, timeout=600):
     start_time = time.monotonic()
     deadline = start_time + timeout
 
-    with GuestAgent(vmid=machine.id) as ga:
+    with GuestAgent(vmid=machine.id, socket_wait_timeout=socket_wait_timeout) as ga:
         while time.monotonic() < deadline:
             elapsed = int(time.monotonic() - start_time)
 
             try:
                 if not checks['cloud_init']:
-                    result = ga.exec("cloud-init status --wait", capture_output=True, timeout=30)
+                    result = ga.exec(
+                        "cloud-init status",
+                        capture_output=True,
+                        timeout=_CLOUD_INIT_EXEC_TIMEOUT,
+                    )
                     if result.exit_code == 0 or "done" in result.stdout.lower():
                         checks['cloud_init'] = True
+                    else:
+                        print(f"[{elapsed}s] cloud-init not done yet: {result.stdout.strip()!r}", flush=True)
                     time.sleep(10)
                     continue
 
@@ -205,27 +214,36 @@ def wait_for_cloud_init_completion(machine, timeout=600):
                     result = ga.exec(
                         ["systemctl", "is-active", "bash_loggin_timer.timer"],
                         capture_output=True,
-                        timeout=30,
+                        timeout=_FAST_EXEC_TIMEOUT,
                     )
                     if result.stdout.strip() == "active":
                         checks['bash_logging_timer'] = True
+                    else:
+                        print(f"[{elapsed}s] bash_loggin_timer not active yet: {result.stdout.strip()!r}", flush=True)
                     time.sleep(10)
                     continue
 
                 flag_result = ga.exec(
                     ["test", "-f", "/var/run/wazuh-setup-complete.flag"],
                     capture_output=False,
-                    timeout=30,
+                    timeout=_FAST_EXEC_TIMEOUT,
                 )
                 timer_result = ga.exec(
                     ["systemctl", "is-active", "bash_loggin_timer.timer"],
                     capture_output=True,
-                    timeout=30,
+                    timeout=_FAST_EXEC_TIMEOUT,
                 )
                 if flag_result.exit_code == 0 and timer_result.stdout.strip() == "active":
                     checks['setup_complete'] = True
                     time.sleep(15)  # stability buffer
                     return True
+                else:
+                    print(
+                        f"[{elapsed}s] waiting for setup: "
+                        f"flag={'present' if flag_result.exit_code == 0 else 'missing'} "
+                        f"timer={timer_result.stdout.strip()!r}",
+                        flush=True,
+                    )
 
             except GuestAgentError as e:
                 print(f"[{elapsed}s] Guest agent error for VM {machine.id}: {type(e).__name__}: {e}", flush=True)

--- a/backend/import_machine_templates.py
+++ b/backend/import_machine_templates.py
@@ -1,8 +1,7 @@
-import subprocess
 from proxmox_api_calls import *
+from qemu_ga_wrapper import GuestAgent, GuestAgentError
 from DatabaseClasses import MachineTemplate, ChallengeTemplate
 from hashlib import sha256
-import json
 import time
 import random
 
@@ -178,87 +177,67 @@ def convert_iso_to_machine_template(disk_file_path, machine_template_id):
 
 def wait_for_cloud_init_completion(machine, timeout=600):
     """
-    Wait until Cloud init finishes and the setup script completes.
+    Wait until Cloud-init finishes and the setup script completes.
     Checks for a flag file created by the setup script and verifies systemd timer.
     """
-    start_time = time.time()
     checks = {
         'cloud_init': False,
         'bash_logging_timer': False,
         'setup_complete': False
     }
 
-    while time.time() - start_time < timeout:
-        elapsed = int(time.time() - start_time)
+    start_time = time.monotonic()
+    deadline = start_time + timeout
 
-        try:
-            # Phase 1: Cloud-init Status
-            if not checks['cloud_init']:
-                cmd = f"qm guest exec {machine.id} -- bash -c \"cloud-init status --wait\""
-                result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
+    with GuestAgent(vmid=machine.id) as ga:
+        while time.monotonic() < deadline:
+            elapsed = int(time.monotonic() - start_time)
 
-                if "done" in result.stdout.lower() or result.returncode == 0:
-                    checks['cloud_init'] = True
+            try:
+                if not checks['cloud_init']:
+                    result = ga.exec("cloud-init status --wait", capture_output=True, timeout=30)
+                    if result.exit_code == 0 or "done" in result.stdout.lower():
+                        checks['cloud_init'] = True
+                    time.sleep(10)
                     continue
 
-            # Phase 2: Check for bash_loggin_timer.timer
-            if checks['cloud_init'] and not checks['bash_logging_timer']:
-                cmd = f"qm guest exec {machine.id} -- bash -c \"systemctl is-active bash_loggin_timer.timer 2>/dev/null\""
-                result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
+                if not checks['bash_logging_timer']:
+                    result = ga.exec(
+                        ["systemctl", "is-active", "bash_loggin_timer.timer"],
+                        capture_output=True,
+                        timeout=30,
+                    )
+                    if result.stdout.strip() == "active":
+                        checks['bash_logging_timer'] = True
+                    time.sleep(10)
+                    continue
 
-                try:
-                    result_data = json.loads(result.stdout)
-                    status = result_data.get('out-data', '').strip()
-                except:
-                    status = result.stdout.strip()
-
-                if status == "active":
-                    checks['bash_logging_timer'] = True
-
-            # Phase 3: Check for Setup-Complete Flag
-            if checks['bash_logging_timer'] and not checks['setup_complete']:
-                cmd = f"qm guest exec {machine.id} -- bash -c \"test -f /var/run/wazuh-setup-complete.flag && echo 'SETUP_COMPLETE'\""
-                result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
-
-                try:
-                    result_data = json.loads(result.stdout)
-                    output = result_data.get('out-data', '').strip()
-                except:
-                    output = result.stdout.strip()
-
-                if "SETUP_COMPLETE" in output:
+                flag_result = ga.exec(
+                    ["test", "-f", "/var/run/wazuh-setup-complete.flag"],
+                    capture_output=False,
+                    timeout=30,
+                )
+                timer_result = ga.exec(
+                    ["systemctl", "is-active", "bash_loggin_timer.timer"],
+                    capture_output=True,
+                    timeout=30,
+                )
+                if flag_result.exit_code == 0 and timer_result.stdout.strip() == "active":
                     checks['setup_complete'] = True
+                    time.sleep(15)  # stability buffer
+                    return True
 
-                    cmd_check = f"qm guest exec {machine.id} -- bash -c \"systemctl is-active bash_loggin_timer.timer 2>/dev/null\""
-                    result_check = subprocess.run(cmd_check, shell=True, capture_output=True, text=True, timeout=30)
+            except GuestAgentError as e:
+                print(f"[{elapsed}s] Guest agent error for VM {machine.id}: {type(e).__name__}: {e}", flush=True)
+            except Exception as e:
+                print(f"[{elapsed}s] Unexpected error for VM {machine.id}: {type(e).__name__}: {e}", flush=True)
 
-                    # Parse JSON output
-                    try:
-                        check_data = json.loads(result_check.stdout)
-                        timer_status = check_data.get('out-data', '').strip()
-                    except:
-                        timer_status = result_check.stdout.strip()
+            time.sleep(10)
 
-                    if timer_status == "active":
-                        # Extra buffer time to ensure everything is stable
-                        time.sleep(15)
-                        return True
-                    else:
-                        checks['setup_complete'] = False  # Reset to check again
-
-        except subprocess.TimeoutExpired as e:
-            print(f"[{elapsed}s] Command timeout for VM {machine.id}: {e}", flush=True)
-        except subprocess.CalledProcessError as e:
-            print(f"[{elapsed}s] Command failed for VM {machine.id}: {e}", flush=True)
-        except Exception as e:
-            print(f"[{elapsed}s] Unexpected error for VM {machine.id}: {type(e).__name__}: {e}", flush=True)
-
-        time.sleep(10)
-
-    # Timeout
     incomplete = [k for k, v in checks.items() if not v]
     raise TimeoutError(
         f"Setup did not complete within {timeout}s for VM {machine.id}. Incomplete: {', '.join(incomplete)}")
+
 
 
 def write_user_data_snippet(snippets_path="/var/lib/vz/snippets/user-data.yaml",

--- a/backend/import_machine_templates.py
+++ b/backend/import_machine_templates.py
@@ -175,12 +175,13 @@ def convert_iso_to_machine_template(disk_file_path, machine_template_id):
         raise RuntimeError(f"Failed to import ISO file: {e1}")
 
 
-def wait_for_cloud_init_completion(machine, timeout=900, socket_wait_timeout=120.0):
+def wait_for_cloud_init_completion(machine, timeout=600):
     """
     Wait until Cloud-init finishes and the setup script completes.
     Checks for a flag file created by the setup script and verifies systemd timer.
     """
-    _CLOUD_INIT_EXEC_TIMEOUT = max(timeout - 60, 120)
+    _PING_TIMEOUT = 120
+    _CLOUD_INIT_EXEC_TIMEOUT = max(timeout - 180, 120) # 120+4*15=180
     _FAST_EXEC_TIMEOUT = 15
 
     checks = {
@@ -192,7 +193,17 @@ def wait_for_cloud_init_completion(machine, timeout=900, socket_wait_timeout=120
     start_time = time.monotonic()
     deadline = start_time + timeout
 
-    with GuestAgent(vmid=machine.id, socket_wait_timeout=socket_wait_timeout) as ga:
+    with GuestAgent(vmid=machine.id) as ga:
+        ping_deadline = time.monotonic() + _PING_TIMEOUT
+        while not ga.ping():
+            if time.monotonic() > ping_deadline:
+                raise TimeoutError(
+                    f"QEMU GA on VM {machine.id} did not become responsive within {_PING_TIMEOUT}s"
+                )
+            time.sleep(2)
+
+        print(f"[Info] GA responsive on VM {machine.id}, starting cloud-init wait", flush=True)
+
         while time.monotonic() < deadline:
             elapsed = int(time.monotonic() - start_time)
 
@@ -383,6 +394,10 @@ def undo_import_machine_templates(challenge_template):
         except Exception:
             try:
                 subprocess.run(["qm", "unlock", str(machine_template.id)], check=True, capture_output=True)
+            except Exception:
+                pass
+            try:
+                subprocess.run(["qm", "stop", str(machine_template.id)], check=True, capture_output=True)
             except Exception:
                 pass
             try:

--- a/backend/launch_challenge.py
+++ b/backend/launch_challenge.py
@@ -382,28 +382,6 @@ def vmid_to_ipv6(vmid, offset=0x1000):
     return f"fd12:3456:789a:1::{high:x}:{low:x}"
 
 
-
-def wait_for_qemu_guest_agent(machine, timeout=120):
-    """
-    Wait until QEMU Guest Agent is ready.
-    """
-    start_time = time.time()
-    deadline = time.monotonic() + timeout
-
-    while time.monotonic() < deadline:
-        try:
-            with GuestAgent(vmid=machine.id) as ga:
-                if ga.ping():
-                    launch_timing_logger(start_time, f"[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
-                    return True
-        except GuestAgentError:
-            pass
-
-        time.sleep(5)
-
-    raise TimeoutError(f"QEMU Guest Agent timeout for VM {machine.id}")
-
-
 def generate_user_specific_flag(flag_secret, user_unique_id):
     """
     Generate a user-specific flag using the secret and user unique id.

--- a/backend/launch_challenge.py
+++ b/backend/launch_challenge.py
@@ -15,6 +15,7 @@ import hashlib
 import hmac
 from launch_timing_logger import launch_timing_logger
 from get_db_connection import db_connection_context
+from qemu_ga_wrapper import GuestAgent, GuestAgentError
 
 load_dotenv(find_dotenv())
 
@@ -384,19 +385,18 @@ def vmid_to_ipv6(vmid, offset=0x1000):
 
 def wait_for_qemu_guest_agent(machine, timeout=120):
     """
-    Wait until QEMU Guest Agent is ready
+    Wait until QEMU Guest Agent is ready.
     """
     start_time = time.time()
+    deadline = time.monotonic() + timeout
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() < deadline:
         try:
-            cmd = f"qm guest exec {machine.id} -- echo 'ready'"
-            result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=10)
-
-            if result.returncode == 0:
-                launch_timing_logger(start_time, f"[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
-                return True
-        except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+            with GuestAgent(vmid=machine.id) as ga:
+                if ga.ping():
+                    launch_timing_logger(start_time, f"[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
+                    return True
+        except GuestAgentError:
             pass
 
         time.sleep(5)
@@ -440,9 +440,9 @@ def process_all_user_specific_flags(challenge, user_email, user_unique_id):
                         machine = m
                         break
 
-                    if machine is None:
-                        print(f"[Warning] Machine template {machine_template_id} not found in challenge", flush=True)
-                        continue
+                if machine is None:
+                    print(f"[Warning] Machine template {machine_template_id} not found in challenge", flush=True)
+                    continue
 
                 if machine.id not in flags_by_machine:
                     flags_by_machine[machine.id] = []
@@ -499,11 +499,16 @@ def write_user_specific_flags_to_vm(machine_id, flags):
 
     if flag_write_command != "":
         flag_write_command = flag_write_command.rstrip(" && ")
-        result = subprocess.run(["qm", "guest", "exec", str(machine_id), "--",
-                    "bash", "-c", flag_write_command], capture_output=True, text=True)
+        try:
+            with GuestAgent(vmid=machine_id) as ga:
+                result = ga.exec(flag_write_command)
+        except GuestAgentError as e:
+            raise RuntimeError(f"Guest agent error while writing flags to VM {machine_id}: {e}") from e
 
-        if result.returncode != 0:
-            raise RuntimeError(f"Failed to write flags to VM {machine_id}: {result.stderr}")
+        if not result:
+            raise RuntimeError(
+                f"Failed to write flags to VM {machine_id}: {result.stderr}"
+            )
 
     launch_timing_logger(start_flag_write_time, f"[FLAG WRITE COMPLETE]", None, None, VM_ID=machine_id)
 

--- a/backend/qemu_ga_wrapper.py
+++ b/backend/qemu_ga_wrapper.py
@@ -1,0 +1,481 @@
+import base64
+import json
+import logging
+import os
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+__all__ = [
+    "GuestAgent",
+    "GuestAgentError",
+    "GATimeoutError",
+    "GANotRunningError",
+    "GACommandError",
+    "GASocketNotFoundError",
+    "ExecResult",
+]
+
+logger = logging.getLogger(__name__)
+
+_SOCKET_DIR = Path("/var/run/qemu-server")
+_DEFAULT_CONNECT_TIMEOUT: float = 5.0
+_DEFAULT_RECV_TIMEOUT: float = 10.0
+_DEFAULT_EXEC_TIMEOUT: float = 30.0
+_RECV_CHUNK: int = 4096
+_GREETING_TIMEOUT: float = 3.0
+
+class GuestAgentError(Exception):
+    """Base exception for all qemu-ga errors."""
+
+
+class GASocketNotFoundError(GuestAgentError):
+    """Socket file does not exist or is not accessible."""
+
+
+class GANotRunningError(GuestAgentError):
+    """The guest agent inside the VM is not responding."""
+
+
+class GATimeoutError(GuestAgentError):
+    """A socket or command operation exceeded the allowed timeout."""
+
+
+class GACommandError(GuestAgentError):
+    """The guest agent returned an error response for a command."""
+
+    def __init__(self, klass: str, desc: str) -> None:
+        super().__init__(f"[{klass}] {desc}")
+        self.klass = klass
+        self.desc = desc
+
+
+@dataclass(slots=True)
+class ExecResult:
+    """Result of a guest-exec call."""
+
+    pid: int
+    exit_code: int = -1
+    stdout: str = ""
+    stderr: str = ""
+    exited: bool = False
+
+    def __bool__(self) -> bool:
+        return self.exit_code == 0
+
+
+class _QEMUGATransport:
+    """JSON transport over AF_UNIX socket."""
+
+    def __init__(
+        self,
+        socket_path: Path,
+        connect_timeout: float = _DEFAULT_CONNECT_TIMEOUT,
+        recv_timeout: float = _DEFAULT_RECV_TIMEOUT,
+    ) -> None:
+        self._path = socket_path
+        self._connect_timeout = connect_timeout
+        self._recv_timeout = recv_timeout
+        self._sock: Optional[socket.socket] = None
+        self._buf = b""
+
+
+    def connect(self) -> None:
+        if not self._path.exists():
+            raise GASocketNotFoundError(
+                f"QEMU-GA socket not found: {self._path}  "
+                f"(is the VM running and qemu-ga installed?)"
+            )
+        if not os.access(self._path, os.R_OK | os.W_OK):
+            raise GASocketNotFoundError(
+                f"No r/w permission on {self._path}  (run as root)"
+            )
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self._connect_timeout)
+        try:
+            sock.connect(str(self._path))
+        except FileNotFoundError:
+            sock.close()
+            raise GASocketNotFoundError(f"Socket vanished: {self._path}")
+        except OSError as exc:
+            sock.close()
+            raise GANotRunningError(
+                f"Cannot connect to {self._path}: {exc}"
+            ) from exc
+
+        sock.settimeout(self._recv_timeout)
+        self._sock = sock
+        self._buf = b""
+        self._flush_greeting()
+        logger.debug("Connected to %s", self._path)
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+            self._buf = b""
+
+    @property
+    def connected(self) -> bool:
+        return self._sock is not None
+
+    def _flush_greeting(self) -> None:
+        """Discard greeting line on first connect."""
+        try:
+            self._read_line(timeout=_GREETING_TIMEOUT)
+        except GATimeoutError:
+            logger.debug("No greeting received. Continuing.")
+
+    def _read_line(self, timeout: Optional[float] = None) -> bytes:
+        assert self._sock is not None
+        effective = timeout if timeout is not None else self._recv_timeout
+        deadline = time.monotonic() + effective
+
+        while True:
+            nl = self._buf.find(b"\n")
+            if nl != -1:
+                line, self._buf = self._buf[:nl], self._buf[nl + 1:]
+                return line
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise GATimeoutError(
+                    f"Timed out waiting for response from {self._path} "
+                    f"(timeout={effective}s)"
+                )
+
+            self._sock.settimeout(min(remaining, self._recv_timeout))
+            try:
+                chunk = self._sock.recv(_RECV_CHUNK)
+            except socket.timeout:
+                raise GATimeoutError(
+                    f"Timed out waiting for response from {self._path}"
+                ) from None
+            except OSError as exc:
+                self.close()
+                raise GANotRunningError(
+                    f"Socket error reading from {self._path}: {exc}"
+                ) from exc
+
+            if not chunk:
+                self.close()
+                raise GANotRunningError(f"Remote end closed socket: {self._path}")
+
+            self._buf += chunk
+
+
+    def call(
+        self,
+        command: str,
+        arguments: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        if not self.connected:
+            raise GANotRunningError("Transport is not connected.")
+
+        payload: Dict[str, Any] = {"execute": command}
+        if arguments:
+            payload["arguments"] = arguments
+
+        raw = json.dumps(payload, separators=(",", ":")) + "\n"
+        logger.debug("-> %s", raw.rstrip())
+
+        assert self._sock is not None
+        try:
+            self._sock.sendall(raw.encode())
+        except OSError as exc:
+            self.close()
+            raise GANotRunningError(f"Failed to send '{command}': {exc}") from exc
+
+        line = self._read_line(timeout=timeout)
+        logger.debug("<- %s", line.decode(errors="replace"))
+
+        try:
+            response = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise GuestAgentError(f"Non-JSON from qemu-ga: {line[:200]!r}") from exc
+
+        if "error" in response:
+            err = response["error"]
+            raise GACommandError(
+                klass=err.get("class", "Unknown"),
+                desc=err.get("desc", str(err)),
+            )
+
+        return response.get("return")
+
+
+def _wrap_for_windows(command: str, args: List[str]) -> List[str]:
+    """Wrap a command in ``cmd.exe /c start /wait /MIN`` for Windows guests.
+
+    The shipped PowerShell on Windows Server 2008 R2 crashes with a Win32Exception when
+    launched in a QGA session because there is no console window handle.
+    Wrapping in ``start /wait /MIN`` provides a minimised window handle and
+    ``-NonInteractive`` suppresses console interaction.
+    """
+
+    def _quote(token: str) -> str:
+        if " " in token or '"' in token:
+            return '"' + token.replace('"', '\\"') + '"'
+        return token
+
+    is_ps = command.lower().endswith("powershell.exe")
+    if is_ps and "-NonInteractive" not in args:
+        args = ["-NonInteractive"] + list(args)
+
+    inner = " ".join(_quote(t) for t in [command] + list(args))
+    return ["cmd.exe", "/c", f"start /wait /MIN {inner}"]
+
+
+class GuestAgent:
+    """QEMU Guest Agent client for a single Proxmox VM."""
+
+    def __init__(
+        self,
+        vmid: int,
+        windows: bool = False,
+        connect_timeout: float = _DEFAULT_CONNECT_TIMEOUT,
+        recv_timeout: float = _DEFAULT_RECV_TIMEOUT,
+        auto_reconnect: bool = True,
+    ) -> None:
+        self.vmid = vmid
+        self.windows = windows
+        self._auto_reconnect = auto_reconnect
+        self._lock = threading.Lock()
+        self._transport = _QEMUGATransport(
+            _resolve_socket_path(vmid),
+            connect_timeout=connect_timeout,
+            recv_timeout=recv_timeout,
+        )
+
+
+    def __enter__(self) -> "GuestAgent":
+        self._ensure_connected()
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+
+    def _ensure_connected(self) -> None:
+        if not self._transport.connected:
+            self._transport.connect()
+
+    def _call(
+        self,
+        command: str,
+        arguments: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        with self._lock:
+            self._ensure_connected()
+            try:
+                return self._transport.call(command, arguments, timeout=timeout)
+            except GANotRunningError:
+                if self._auto_reconnect:
+                    logger.warning(
+                        "VM %s: connection lost. Reconnecting...", self.vmid
+                    )
+                    self._transport.close()
+                    self._transport.connect()
+                    return self._transport.call(command, arguments, timeout=timeout)
+                raise
+
+    def close(self) -> None:
+        with self._lock:
+            self._transport.close()
+
+
+    def ping(self) -> bool:
+        """Return True if qemu-ga is alive.  Never raises."""
+        try:
+            self._call("guest-ping")
+            return True
+        except GuestAgentError as exc:
+            logger.debug("ping failed for VM %s: %s", self.vmid, exc)
+            return False
+
+
+    def exec(
+        self,
+        command: Union[str, Sequence[str]],
+        *,
+        capture_output: bool = True,
+        input_data: Optional[bytes] = None,
+        timeout: float = _DEFAULT_EXEC_TIMEOUT,
+        poll_interval: float = 0.25,
+        env: Optional[Dict[str, str]] = None,
+    ) -> ExecResult:
+        """Execute a command inside the guest and wait for it to finish."""
+        if isinstance(command, str):
+            argv: List[str] = ["/bin/sh", "-c", command]
+        else:
+            argv = list(command)
+
+        if self.windows:
+            return self._exec_windows(argv, timeout=timeout)
+        return self._exec_socket(
+            argv,
+            capture_output=capture_output,
+            input_data=input_data,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            env=env,
+        )
+
+    def _exec_socket(
+        self,
+        argv: List[str],
+        capture_output: bool,
+        input_data: Optional[bytes],
+        timeout: float,
+        poll_interval: float,
+        env: Optional[Dict[str, str]],
+    ) -> ExecResult:
+        args: Dict[str, Any] = {
+            "path": argv[0],
+            "arg": argv[1:],
+            "capture-output": capture_output,
+        }
+        if input_data is not None:
+            args["input-data"] = base64.b64encode(input_data).decode()
+        if env:
+            args["env"] = [f"{k}={v}" for k, v in env.items()]
+
+        result = self._call("guest-exec", args)
+        pid: int = result["pid"]
+
+        deadline = time.monotonic() + timeout
+        while True:
+            status = self._call("guest-exec-status", {"pid": pid})
+            if status.get("exited"):
+                return ExecResult(
+                    pid=pid,
+                    exit_code=status.get("exitcode", -1),
+                    stdout=_b64decode_str(status.get("out-data", "")),
+                    stderr=_b64decode_str(status.get("err-data", "")),
+                    exited=True,
+                )
+            if time.monotonic() > deadline:
+                raise GATimeoutError(
+                    f"VM {self.vmid}: {argv!r} did not exit within "
+                    f"{timeout}s (pid={pid})"
+                )
+            time.sleep(poll_interval)
+
+    def _exec_windows(self, argv: List[str], timeout: float) -> ExecResult:
+        """Execute a command on a Windows guest.
+
+        Attempts direct ``guest-exec`` first.  If the process is PowerShell
+        and returns no output with a non-zero exit code the call is
+        retried wrapped in ``cmd.exe /c start /wait /MIN`` to supply a window handle.
+        """
+        is_ps = argv[0].lower().endswith("powershell.exe")
+        command, args = argv[0], argv[1:]
+
+        try:
+            result = self._exec_socket(
+                argv,
+                capture_output=True,
+                input_data=None,
+                timeout=timeout,
+                poll_interval=0.5,
+                env=None,
+            )
+            if result.exit_code == 0:
+                return result
+            # PS with no output is a console-handle crash on legacy Windows -> retry
+            if is_ps and not result.stdout and not result.stderr:
+                pass
+            else:
+                return result
+        except GACommandError:
+            if not is_ps:
+                raise
+
+        wrapped = _wrap_for_windows(command, args)
+        return self._exec_socket(
+            wrapped,
+            capture_output=True,
+            input_data=None,
+            timeout=timeout,
+            poll_interval=0.5,
+            env=None,
+        )
+
+
+    def read_file(self, guest_path: str, *, chunk_size: int = 65536) -> bytes:
+        """Read a file from inside the guest and return its contents."""
+        handle: int = self._call(
+            "guest-file-open", {"path": guest_path, "mode": "r"}
+        )
+        buf = bytearray()
+        try:
+            while True:
+                chunk = self._call(
+                    "guest-file-read",
+                    {"handle": handle, "count": chunk_size},
+                )
+                if chunk.get("buf-b64"):
+                    buf.extend(base64.b64decode(chunk["buf-b64"]))
+                if chunk.get("eof"):
+                    break
+        finally:
+            try:
+                self._call("guest-file-close", {"handle": handle})
+            except GuestAgentError:
+                pass
+        return bytes(buf)
+
+
+    def write_file(
+        self,
+        guest_path: str,
+        data: Union[bytes, str],
+        *,
+        mode: str = "w",
+    ) -> None:
+        """Write data to guest_path inside the guest."""
+        raw = data.encode("utf-8") if isinstance(data, str) else data
+        handle: int = self._call(
+            "guest-file-open", {"path": guest_path, "mode": mode}
+        )
+        try:
+            self._call(
+                "guest-file-write",
+                {"handle": handle, "buf-b64": base64.b64encode(raw).decode()},
+            )
+            self._call("guest-file-flush", {"handle": handle})
+        finally:
+            try:
+                self._call("guest-file-close", {"handle": handle})
+            except GuestAgentError:
+                pass
+
+
+def _resolve_socket_path(vmid: int) -> Path:
+    if not _SOCKET_DIR.is_dir():
+        raise GASocketNotFoundError(
+            f"Socket directory {_SOCKET_DIR} not found"
+        )
+    return _SOCKET_DIR / f"{vmid}.qga"
+
+
+def _b64decode_str(value: str, encoding: str = "utf-8") -> str:
+    if not value:
+        return ""
+    try:
+        return base64.b64decode(value).decode(encoding, errors="replace")
+    except Exception:
+        return ""

--- a/backend/qemu_ga_wrapper.py
+++ b/backend/qemu_ga_wrapper.py
@@ -83,7 +83,36 @@ class _QEMUGATransport:
         self._buf = b""
 
 
-    def connect(self) -> None:
+    def wait_for_socket(
+        self,
+        timeout: float = 120.0,
+        poll_interval: float = 1.0,
+    ) -> None:
+        """Block until the socket file appears and is accessible, or raise."""
+        deadline = time.monotonic() + timeout
+        while True:
+            if self._path.exists() and os.access(self._path, os.R_OK | os.W_OK):
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise GATimeoutError(
+                    f"Socket {self._path} did not appear within {timeout}s "
+                    f"(is the VM booting and qemu-ga installed?)"
+                )
+            logger.debug(
+                "Waiting for socket %s (%.0fs remaining)…",
+                self._path,
+                remaining,
+            )
+            time.sleep(min(poll_interval, remaining))
+
+    def connect(self, *, wait_timeout: Optional[float] = None) -> None:
+        """Connect to the socket, optionally waiting for it to appear first."""
+        import errno as _errno
+
+        if wait_timeout is not None:
+            self.wait_for_socket(timeout=wait_timeout)
+
         if not self._path.exists():
             raise GASocketNotFoundError(
                 f"QEMU-GA socket not found: {self._path}  "
@@ -94,27 +123,57 @@ class _QEMUGATransport:
                 f"No r/w permission on {self._path}  (run as root)"
             )
 
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(self._connect_timeout)
-        try:
-            sock.connect(str(self._path))
-        except FileNotFoundError:
-            sock.close()
-            raise GASocketNotFoundError(f"Socket vanished: {self._path}")
-        except OSError as exc:
-            sock.close()
-            raise GANotRunningError(
-                f"Cannot connect to {self._path}: {exc}"
-            ) from exc
+        deadline = time.monotonic() + self._connect_timeout
+        last_exc: Optional[OSError] = None
+        while time.monotonic() < deadline:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.setblocking(True)
+            try:
+                sock.connect(str(self._path))
+                sock.settimeout(self._recv_timeout)
+                self._sock = sock
+                self._buf = b""
+                self._flush_greeting()
+                logger.debug("Connected to %s", self._path)
+                return
+            except FileNotFoundError:
+                sock.close()
+                raise GASocketNotFoundError(f"Socket vanished: {self._path}")
+            except OSError as exc:
+                sock.close()
+                if exc.errno == _errno.EAGAIN:
+                    last_exc = exc
+                    logger.debug(
+                        "EAGAIN on connect to %s, retrying…", self._path
+                    )
+                    time.sleep(0.2)
+                    continue
+                raise GANotRunningError(
+                    f"Cannot connect to {self._path}: {exc}"
+                ) from exc
 
-        sock.settimeout(self._recv_timeout)
-        self._sock = sock
-        self._buf = b""
-        self._flush_greeting()
-        logger.debug("Connected to %s", self._path)
+        raise GANotRunningError(
+            f"Cannot connect to {self._path} after retrying for "
+            f"{self._connect_timeout}s: {last_exc}"
+        ) from last_exc
+
+    def _drain(self, timeout: float = 2.0) -> None:
+        """Read and discard everything pending in the socket buffer."""
+        if self._sock is None:
+            return
+        deadline = time.monotonic() + timeout
+        try:
+            while time.monotonic() < deadline:
+                self._sock.settimeout(min(0.1, deadline - time.monotonic()))
+                chunk = self._sock.recv(_RECV_CHUNK)
+                if not chunk:
+                    break
+        except OSError:
+            pass
 
     def close(self) -> None:
         if self._sock is not None:
+            self._drain()
             try:
                 self._sock.shutdown(socket.SHUT_RDWR)
             except OSError:
@@ -131,11 +190,29 @@ class _QEMUGATransport:
         return self._sock is not None
 
     def _flush_greeting(self) -> None:
-        """Discard greeting line on first connect."""
+        """Discard optional greeting line emitted on first connect."""
+        assert self._sock is not None
+        deadline = time.monotonic() + _GREETING_TIMEOUT
         try:
-            self._read_line(timeout=_GREETING_TIMEOUT)
-        except GATimeoutError:
-            logger.debug("No greeting received. Continuing.")
+            while time.monotonic() < deadline:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._sock.settimeout(min(remaining, _GREETING_TIMEOUT))
+                try:
+                    chunk = self._sock.recv(_RECV_CHUNK)
+                except socket.timeout:
+                    logger.debug("No greeting received from %s. Continuing.", self._path)
+                    return
+                if not chunk:
+                    return
+                self._buf += chunk
+                nl = self._buf.find(b"\n")
+                if nl != -1:
+                    self._buf = self._buf[nl + 1:]
+                    return
+        except OSError:
+            pass
 
     def _read_line(self, timeout: Optional[float] = None) -> bytes:
         assert self._sock is not None
@@ -150,6 +227,7 @@ class _QEMUGATransport:
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                self.close()  # socket is dirty -> force reconnect on next call
                 raise GATimeoutError(
                     f"Timed out waiting for response from {self._path} "
                     f"(timeout={effective}s)"
@@ -159,6 +237,7 @@ class _QEMUGATransport:
             try:
                 chunk = self._sock.recv(_RECV_CHUNK)
             except socket.timeout:
+                self.close()  # socket is dirty -> force reconnect on next call
                 raise GATimeoutError(
                     f"Timed out waiting for response from {self._path}"
                 ) from None
@@ -248,10 +327,12 @@ class GuestAgent:
         connect_timeout: float = _DEFAULT_CONNECT_TIMEOUT,
         recv_timeout: float = _DEFAULT_RECV_TIMEOUT,
         auto_reconnect: bool = True,
+        socket_wait_timeout: Optional[float] = None,
     ) -> None:
         self.vmid = vmid
         self.windows = windows
         self._auto_reconnect = auto_reconnect
+        self._socket_wait_timeout = socket_wait_timeout
         self._lock = threading.Lock()
         self._transport = _QEMUGATransport(
             _resolve_socket_path(vmid),
@@ -270,7 +351,7 @@ class GuestAgent:
 
     def _ensure_connected(self) -> None:
         if not self._transport.connected:
-            self._transport.connect()
+            self._transport.connect(wait_timeout=self._socket_wait_timeout)
 
     def _call(
         self,
@@ -282,10 +363,10 @@ class GuestAgent:
             self._ensure_connected()
             try:
                 return self._transport.call(command, arguments, timeout=timeout)
-            except GANotRunningError:
+            except (GANotRunningError, GATimeoutError):
                 if self._auto_reconnect:
                     logger.warning(
-                        "VM %s: connection lost. Reconnecting...", self.vmid
+                        "VM %s: connection lost or timed out. Reconnecting...", self.vmid
                     )
                     self._transport.close()
                     self._transport.connect()

--- a/backend/qemu_ga_wrapper.py
+++ b/backend/qemu_ga_wrapper.py
@@ -27,6 +27,7 @@ _DEFAULT_RECV_TIMEOUT: float = 10.0
 _DEFAULT_EXEC_TIMEOUT: float = 30.0
 _RECV_CHUNK: int = 4096
 _GREETING_TIMEOUT: float = 3.0
+_DEFAULT_SOCKET_WAIT_TIMEOUT: float = 120.0
 
 class GuestAgentError(Exception):
     """Base exception for all qemu-ga errors."""
@@ -327,7 +328,7 @@ class GuestAgent:
         connect_timeout: float = _DEFAULT_CONNECT_TIMEOUT,
         recv_timeout: float = _DEFAULT_RECV_TIMEOUT,
         auto_reconnect: bool = True,
-        socket_wait_timeout: Optional[float] = None,
+        socket_wait_timeout: Optional[float] = _DEFAULT_SOCKET_WAIT_TIMEOUT,
     ) -> None:
         self.vmid = vmid
         self.windows = windows

--- a/backend/warmup_challenge.py
+++ b/backend/warmup_challenge.py
@@ -265,14 +265,15 @@ def configure_wazuh_for_challenge(challenge, manager_ip="fd12:3456:789a:1::101")
 
 def wait_for_qemu_guest_agent(machine, timeout=120):
     """
-    Wait until QEMU Guest Agent is ready
+    Wait until QEMU Guest Agent is ready.
     """
     start_time = time.time()
     deadline = time.monotonic() + timeout
+    socket_wait_timeout = max(10.0, timeout * 0.9)
 
     while time.monotonic() < deadline:
         try:
-            with GuestAgent(vmid=machine.id) as ga:
+            with GuestAgent(vmid=machine.id, socket_wait_timeout=socket_wait_timeout) as ga:
                 if ga.ping():
                     launch_timing_logger(start_time, f"[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
                     return True

--- a/backend/warmup_challenge.py
+++ b/backend/warmup_challenge.py
@@ -269,18 +269,13 @@ def wait_for_qemu_guest_agent(machine, timeout=120):
     """
     start_time = time.time()
     deadline = time.monotonic() + timeout
-    socket_wait_timeout = max(10.0, timeout * 0.9)
 
-    while time.monotonic() < deadline:
-        try:
-            with GuestAgent(vmid=machine.id, socket_wait_timeout=socket_wait_timeout) as ga:
-                if ga.ping():
-                    launch_timing_logger(start_time, f"[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
-                    return True
-        except GuestAgentError:
-            pass
-
-        time.sleep(5)
+    with GuestAgent(vmid=machine.id) as ga:
+        while time.monotonic() < deadline:
+            if ga.ping():
+                launch_timing_logger(start_time, "[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
+                return True
+            time.sleep(5)
 
     raise TimeoutError(f"QEMU Guest Agent timeout for VM {machine.id}")
 

--- a/backend/warmup_challenge.py
+++ b/backend/warmup_challenge.py
@@ -15,6 +15,7 @@ import hashlib
 import hmac
 from launch_timing_logger import launch_timing_logger
 from get_db_connection import db_connection_context
+from qemu_ga_wrapper import GuestAgent, GuestAgentError
 
 load_dotenv(find_dotenv())
 
@@ -267,16 +268,15 @@ def wait_for_qemu_guest_agent(machine, timeout=120):
     Wait until QEMU Guest Agent is ready
     """
     start_time = time.time()
+    deadline = time.monotonic() + timeout
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() < deadline:
         try:
-            cmd = f"qm guest exec {machine.id} -- echo 'ready'"
-            result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=10)
-
-            if result.returncode == 0:
-                launch_timing_logger(start_time, f"[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
-                return True
-        except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+            with GuestAgent(vmid=machine.id) as ga:
+                if ga.ping():
+                    launch_timing_logger(start_time, f"[GUEST AGENT RESPONDED]", machine.challenge.template.id, None, VM_ID=machine.id)
+                    return True
+        except GuestAgentError:
             pass
 
         time.sleep(5)
@@ -313,14 +313,13 @@ def configure_ipv6_and_wazuh_via_guest_agent(machine, manager_ip="fd12:3456:789a
     rm -rf /var/monitoring
     """
 
-    cmd = [
-        "qm", "guest", "exec", str(machine.id),
-        "--", "bash", "-c", aggregated_cmd
-    ]
+    try:
+        with GuestAgent(vmid=machine.id) as ga:
+            result = ga.exec(aggregated_cmd, timeout=120)
+    except GuestAgentError as e:
+        raise RuntimeError(f"Guest agent error while configuring Wazuh for VM {machine.id}: {e}") from e
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-
-    if result.returncode != 0:
+    if not result:
         raise RuntimeError(
             f"Failed to configure Wazuh for VM {machine.id}: {result.stderr}"
         )


### PR DESCRIPTION
## Description
Implements direct qemu-guest-agent socket communication to replace qm guest exec for all provisioning command execution.
Previously, provisioning commands were executed by using `qm guest exec`, which added Proxmox CLI overhead on every command and failed entirely on guest OSes not supported by the PVE toolchain. This PR introduces qemu_ga_wrapper.py, a purpose-built client that communicates directly with the QEMU guest agent over its AF_UNIX socket, and migrates all provisioning workflows to use it.
The wrapper is used across import_machine_templates.py, warmup_challenge.py, and launch_challenge.py for cloud-init completion waiting, guest agent readiness polling, and user-specific flag delivery to VMs.

Fixes #17 

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Create Challenge
- [x] Launch challenge
- [x] Test currently unused functions read and write via the guest agent 

**Test Configuration**:
* OS: Ubuntu 22.04, VirtualBox 7.1.4
* Proxmox Version: 9.1.1
* Components affected: backend