### PR TITLE
Fix installer path in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ### Prerequisites
 - Proxmox VE 9.1-1, other versions might work but are not tested yet
-- Python 3.x, the [installer](setup/bin/install) will install version 3.12 to ensure compatibility with all dependencies during the installation process
+- Python 3.x, the [installer](bin/install) will install version 3.12 to ensure compatibility with all dependencies during the installation process
 - `root` access to the Proxmox VE host, including the `root` password, Proxmox's hostname, and information about the network configuration (internal and external IP address if the application will run in a NAT environment)
 
 ### Quick Installation


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to reference the correct installer script path, ensuring clarity and accuracy for users.

Documentation update:

* Updated the installer script path from `setup/bin/install` to `bin/install` in the prerequisites section of `README.md` to reflect the correct location of the Python installer.